### PR TITLE
Change Search Result Id from Int to Long

### DIFF
--- a/Source/Podio .NET/Models/Request/SearchReferencesRequest.cs
+++ b/Source/Podio .NET/Models/Request/SearchReferencesRequest.cs
@@ -44,7 +44,7 @@ namespace PodioAPI.Models.Request
         ///     if target = "item_field". A list of item id's that should be excluded from the result.
         /// </summary>
         [JsonProperty("not_item_ids", NullValueHandling = NullValueHandling.Ignore)]
-        public List<int> NotItemIds { get; set; }
+        public List<long> NotItemIds { get; set; }
 
         /// <summary>
         ///     if  target = "item_created_by", "item_created_via" or "item_tags". Id of the app to search for.

--- a/Source/Podio .NET/Models/Request/TaskCreateUpdateRequest.cs
+++ b/Source/Podio .NET/Models/Request/TaskCreateUpdateRequest.cs
@@ -105,7 +105,7 @@ namespace PodioAPI.Models.Request
         ///     The reference id for the task. Only for task update operation
         /// </summary>
         [JsonProperty("ref_id", NullValueHandling = NullValueHandling.Ignore)]
-        public int? Id { get; set; }
+        public long? Id { get; set; }
 
         public void SetResponsible(IEnumerable<int> userIds)
         {

--- a/Source/Podio .NET/Models/SearchResult.cs
+++ b/Source/Podio .NET/Models/SearchResult.cs
@@ -9,7 +9,7 @@ namespace PodioAPI.Models
     {
        
         [JsonProperty("id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/Source/Podio .NET/Models/Task.cs
+++ b/Source/Podio .NET/Models/Task.cs
@@ -7,7 +7,7 @@ namespace PodioAPI.Models
     public class Task
     {
         [JsonProperty("task_id")]
-        public int TaskId { get; set; }
+        public long TaskId { get; set; }
 
         [JsonProperty("status")]
         public string Status { get; set; }

--- a/Source/Podio .NET/Services/TaskService.cs
+++ b/Source/Podio .NET/Services/TaskService.cs
@@ -73,7 +73,7 @@ namespace PodioAPI.Services
         /// <param name="refId"></param>
         /// <param name="limit"></param>
         /// <returns></returns>
-        public async Task<TaskSummary> GetTaskSummaryForReference(string refType, int refId, int limit = 4)
+        public async Task<TaskSummary> GetTaskSummaryForReference(string refType, long refId, int limit = 4)
         {
             string url = string.Format("/task/{0}/{1}/summary", refType, refId);
             var requestData = new Dictionary<string, string>()
@@ -107,7 +107,7 @@ namespace PodioAPI.Services
         /// <param name="refType"></param>
         /// <param name="refId"></param>
         /// <returns></returns>
-        public async Task<int> GetTaskCount(string refType, int refId)
+        public async Task<int> GetTaskCount(string refType, long refId)
         {
             string url = string.Format("/task/{0}/{1}/count", refType, refId);
             dynamic response = await _podio.Get<dynamic>(url);
@@ -131,7 +131,7 @@ namespace PodioAPI.Services
         /// </summary>
         /// <param name="taskId"></param>
         /// <returns></returns>
-        public async Task<Models.Task> GetTask(int taskId)
+        public async Task<Models.Task> GetTask(long taskId)
         {
             string url = string.Format("/task/{0}", taskId);
             return await _podio.Get<Models.Task>(url);
@@ -165,7 +165,7 @@ namespace PodioAPI.Services
         ///     If set to true, the object will not be bumped up in the stream and notifications will not be
         ///     generated. Default value: false
         /// </param>
-        public async System.Threading.Tasks.Task IncompleteTask(int taskId, bool hook = true, bool silent = false)
+        public async System.Threading.Tasks.Task IncompleteTask(long taskId, bool hook = true, bool silent = false)
         {
             string url = string.Format("/task/{0}/incomplete", taskId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent, hook));
@@ -185,7 +185,7 @@ namespace PodioAPI.Services
         ///     generated. Default value: false
         /// </param>
         /// <returns></returns>
-        public async Task<List<Models.Task>> CreateTask(TaskCreateUpdateRequest task, string refType = null, int? refId = null,
+        public async Task<List<Models.Task>> CreateTask(TaskCreateUpdateRequest task, string refType = null, long? refId = null,
             bool hook = true, bool silent = false)
         {
             string url = "/task/";
@@ -195,7 +195,7 @@ namespace PodioAPI.Services
             }
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent, hook));
             var createdTasks = new List<Models.Task>();
-            if ((task.Responsible is IEnumerable<int> || task.Responsible is IEnumerable<Ref>) &&
+            if ((task.Responsible is IEnumerable<long> || task.Responsible is IEnumerable<Ref>) &&
                 task.Responsible.Count > 1)
             {
                 List<Models.Task> response = await _podio.Post<List<Models.Task>>(url, task);
@@ -227,7 +227,7 @@ namespace PodioAPI.Services
         /// </param>
         /// <returns></returns>
         public async Task<List<Models.Task>> CreateTask(string text, DateTime? dueDate = null, string description = null,
-            int? responsible = null, bool isPrivate = true, string refType = null, int? refId = null, bool hook = true,
+            long? responsible = null, bool isPrivate = true, string refType = null, long? refId = null, bool hook = true,
             bool silent = false)
         {
             var task = new TaskCreateUpdateRequest
@@ -253,7 +253,7 @@ namespace PodioAPI.Services
         ///     generated. Default value: false
         /// </param>
         /// <returns></returns>
-        public async Task<Models.Task> UpdateTask(int taskId, TaskCreateUpdateRequest task, bool hook = true, bool silent = false)
+        public async Task<Models.Task> UpdateTask(long taskId, TaskCreateUpdateRequest task, bool hook = true, bool silent = false)
         {
             string url = string.Format("/task/{0}", taskId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent, hook));
@@ -270,7 +270,7 @@ namespace PodioAPI.Services
         ///     If set to true, the object will not be bumped up in the stream and notifications will not be
         ///     generated. Default value: false
         /// </param>
-        public async System.Threading.Tasks.Task DeleteTask(int taskId, bool hook = true, bool silent = false)
+        public async System.Threading.Tasks.Task DeleteTask(long taskId, bool hook = true, bool silent = false)
         {
             string url = string.Format("/task/{0}", taskId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent, hook));
@@ -295,7 +295,7 @@ namespace PodioAPI.Services
         /// <param name="taskId"></param>
         /// <param name="beforeTaskId"></param>
         /// <param name="afterTaskId"></param>
-        public async System.Threading.Tasks.Task RankTask(int taskId, int beforeTaskId, int afterTaskId)
+        public async System.Threading.Tasks.Task RankTask(long taskId, long beforeTaskId, long afterTaskId)
         {
             string url = string.Format("/task/{0}/rank", taskId);
             dynamic requestData = new
@@ -311,7 +311,7 @@ namespace PodioAPI.Services
         ///     <para>API Reference: https://developers.podio.com/doc/tasks/remove-task-reference-6146114 </para>
         /// </summary>
         /// <param name="taskId"></param>
-        public async System.Threading.Tasks.Task RemoveTaskReference(int taskId)
+        public async System.Threading.Tasks.Task RemoveTaskReference(long taskId)
         {
             string url = string.Format("/task/{0}/ref", taskId);
             await _podio.Delete<dynamic>(url);
@@ -324,7 +324,7 @@ namespace PodioAPI.Services
         /// <param name="labelId"></param>
         /// <param name="text">The name of the new label</param>
         /// <param name="color">The color of the label in hex format (xxxxxx)</param>
-        public async System.Threading.Tasks.Task UpdateLabel(int labelId, string text, string color)
+        public async System.Threading.Tasks.Task UpdateLabel(long labelId, string text, string color)
         {
             string url = string.Format("/task/label/{0}", labelId);
             dynamic requestData = new
@@ -343,7 +343,7 @@ namespace PodioAPI.Services
         /// <param name="description"></param>
         /// <param name="hook"></param>
         /// <param name="silent"></param>
-        public async System.Threading.Tasks.Task UpdateTaskDescription(int taskId, string description, bool hook = true, bool silent = false)
+        public async System.Threading.Tasks.Task UpdateTaskDescription(long taskId, string description, bool hook = true, bool silent = false)
         {
             string url = string.Format("/task/{0}/description", taskId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent, hook));
@@ -362,7 +362,7 @@ namespace PodioAPI.Services
         /// <param name="isPrivate">True if the task should be private, false otherwise</param>
         /// <param name="hook"></param>
         /// <param name="silent"></param>
-        public async System.Threading.Tasks.Task UpdateTaskPrivate(int taskId, bool isPrivate, bool hook = true, bool silent = false)
+        public async System.Threading.Tasks.Task UpdateTaskPrivate(long taskId, bool isPrivate, bool hook = true, bool silent = false)
         {
             string url = string.Format("/task/{0}/private", taskId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent, hook));
@@ -381,7 +381,7 @@ namespace PodioAPI.Services
         /// <param name="text">The new text of the task</param>
         /// <param name="hook"></param>
         /// <param name="silent"></param>
-        public async System.Threading.Tasks.Task UpdateTaskText(int taskId, string text, bool hook = true, bool silent = false)
+        public async System.Threading.Tasks.Task UpdateTaskText(long taskId, string text, bool hook = true, bool silent = false)
         {
             string url = string.Format("/task/{0}/text", taskId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent, hook));
@@ -401,7 +401,7 @@ namespace PodioAPI.Services
         /// <param name="dueDateTime">The date and time the task is due (in local date and time)</param>
         /// <param name="hook"></param>
         /// <param name="silent"></param>
-        public async System.Threading.Tasks.Task UpdateTaskDueOn(int taskId, DateTime dueOn, DateTime dueDateTime, bool hook = true,
+        public async System.Threading.Tasks.Task UpdateTaskDueOn(long taskId, DateTime dueOn, DateTime dueDateTime, bool hook = true,
             bool silent = false)
         {
             string url = string.Format("/task/{0}/due", taskId);
@@ -421,7 +421,7 @@ namespace PodioAPI.Services
         /// </summary>
         /// <param name="taskId"></param>
         /// <param name="labelIds"></param>
-        public async System.Threading.Tasks.Task UpdateTaskLabels(int taskId, List<int> labelIds)
+        public async System.Threading.Tasks.Task UpdateTaskLabels(long taskId, List<int> labelIds)
         {
             string url = string.Format("/task/{0}/label/", taskId);
             dynamic requestData = labelIds;
@@ -438,7 +438,7 @@ namespace PodioAPI.Services
         /// <param name="refId"></param>
         /// <param name="hook"></param>
         /// <param name="silent"></param>
-        public async System.Threading.Tasks.Task UpdateTaskReference(int taskId, string refType, int refId, bool hook = true, bool silent = false)
+        public async System.Threading.Tasks.Task UpdateTaskReference(long taskId, string refType, int refId, bool hook = true, bool silent = false)
         {
             string url = string.Format("/task/{0}/ref", taskId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent, hook));
@@ -496,7 +496,7 @@ namespace PodioAPI.Services
             string completedOn = null, int? createdBy = null, string createdOn = null, int? createdVia = null,
             string dueDate = null, string externalId = null, bool? files = null, string grouping = null,
             int? label = null, int? limit = null, int offset = 0, int? org = null, bool? reassigned = null,
-            string reference = null, int? responsible = null, string sort_by = "rank", bool sortDesc = false,
+            string reference = null, long? responsible = null, string sort_by = "rank", bool sortDesc = false,
             int? space = null, string view = null)
         {
             string url = "/task/";
@@ -578,7 +578,7 @@ namespace PodioAPI.Services
         ///     generated. Default value: false.
         /// </param>
         /// <returns></returns>
-        public async Task<int?> CompleteTask(int taskId, bool hook = true, bool silent = false)
+        public async Task<int?> CompleteTask(long taskId, bool hook = true, bool silent = false)
         {
             string url = string.Format("/task/{0}/complete", taskId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent, hook));
@@ -598,7 +598,7 @@ namespace PodioAPI.Services
         ///     generated. Default value: false.
         /// </param>
         /// <param name="responsible">The contact responsible (user_id), or null if no one should be responsible.</param>
-        public async System.Threading.Tasks.Task AssignTask(int taskId, int? responsible = null, bool silent = false)
+        public async System.Threading.Tasks.Task AssignTask(long taskId, int? responsible = null, bool silent = false)
         {
             string url = string.Format("/task/{0}/assign", taskId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent));

--- a/Source/Podio.Async/Podio.Async.csproj
+++ b/Source/Podio.Async/Podio.Async.csproj
@@ -17,7 +17,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <RootNamespace>Podio.Async</RootNamespace>
     <Authors>Podio.Async</Authors>
-    <Version>2.0.6</Version>
+    <Version>2.0.7</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>A fork of podio-dotnet / Podio.Async</Description>
     <Company />


### PR DESCRIPTION
Search results can contain items and also are required to be migrated to `long`. Might be easier if all `Id` types just get migrate to `long`.